### PR TITLE
Synchronizer events patch

### DIFF
--- a/ElectrodZMultiplayer/Core/Abstract/ASynchronizer.cs
+++ b/ElectrodZMultiplayer/Core/Abstract/ASynchronizer.cs
@@ -90,6 +90,11 @@ namespace ElectrodZMultiplayer
         public abstract event ListAvailableGameModesFailedDelegate OnListAvailableGameModesFailed;
 
         /// <summary>
+        /// This event will be invoked when an user has joined this lobby.
+        /// </summary>
+        public abstract event LobbyUserJoinedDelegate OnUserJoined;
+
+        /// <summary>
         /// This event will be invoked when joining a lobby has failed.
         /// </summary>
         public abstract event JoinLobbyFailedDelegate OnJoinLobbyFailed;
@@ -100,14 +105,34 @@ namespace ElectrodZMultiplayer
         public abstract event CreateLobbyFailedDelegate OnCreateLobbyFailed;
 
         /// <summary>
+        /// This event will be invoked when an user left this lobby.
+        /// </summary>
+        public abstract event LobbyUserLeftDelegate OnUserLeft;
+
+        /// <summary>
+        /// This event will be invoked when the username changes.
+        /// </summary>
+        public abstract event UserUsernameUpdatedDelegate OnUsernameUpdated;
+
+        /// <summary>
         /// This event will be invoked when changing username has failed.
         /// </summary>
         public abstract event ChangeUsernameFailedDelegate OnChangeUsernameFailed;
 
         /// <summary>
+        /// This event will be invoked when the user lobby color changes.
+        /// </summary>
+        public abstract event UserUserLobbyColorUpdatedDelegate OnUserLobbyColorUpdated;
+
+        /// <summary>
         /// This event will be invoked when changing user lobby color has failed.
         /// </summary>
         public abstract event ChangeUserLobbyColorFailedDelegate OnChangeUserLobbyColorFailed;
+
+        /// <summary>
+        /// This event will be invoked when the lobby rules of this lobby has been updated.
+        /// </summary>
+        public abstract event LobbyLobbyRulesUpdatedDelegate OnLobbyRulesUpdated;
 
         /// <summary>
         /// This event will be invoked when changing lobby rules have failed.
@@ -120,9 +145,29 @@ namespace ElectrodZMultiplayer
         public abstract event KickUserFailedDelegate OnKickUserFailed;
 
         /// <summary>
+        /// This event will be invoked when a game has been started.
+        /// </summary>
+        public abstract event LobbyGameStartedDelegate OnGameStarted;
+
+        /// <summary>
+        /// This event will be invoked when a game start has been requested.
+        /// </summary>
+        public abstract event LobbyGameStartRequestedDelegate OnGameStartRequested;
+
+        /// <summary>
         /// This event will be invoked when starting a game has failed.
         /// </summary>
         public abstract event StartGameFailedDelegate OnStartGameFailed;
+
+        /// <summary>
+        /// This event will be invoked when a game has been restarted.
+        /// </summary>
+        public abstract event LobbyGameRestartedDelegate OnGameRestarted;
+
+        /// <summary>
+        /// This event will be invoked when a game restart has been requested.
+        /// </summary>
+        public abstract event LobbyGameRestartRequestedDelegate OnGameRestartRequested;
 
         /// <summary>
         /// This event will be invoked when restarting a game has failed.
@@ -130,14 +175,39 @@ namespace ElectrodZMultiplayer
         public abstract event RestartGameFailedDelegate OnRestartGameFailed;
 
         /// <summary>
+        /// This event will be invoked when a game has been stopped.
+        /// </summary>
+        public abstract event LobbyGameStoppedDelegate OnGameStopped;
+
+        /// <summary>
+        /// This event will be invoked when a game stop has been requested.
+        /// </summary>
+        public abstract event LobbyGameStopRequestedDelegate OnGameStopRequested;
+
+        /// <summary>
         /// This event will be invoked when stopping a game has failed.
         /// </summary>
         public abstract event StopGameFailedDelegate OnStopGameFailed;
 
         /// <summary>
+        /// This event will be invoked when a client tick has been performed.
+        /// </summary>
+        public abstract event UserClientTickedDelegate OnClientTicked;
+
+        /// <summary>
         /// This event will be invoked when a client tick has failed.
         /// </summary>
         public abstract event ClientTickFailedDelegate OnClientTickFailed;
+
+        /// <summary>
+        /// This event will be invoked when a server tick has been performed.
+        /// </summary>
+        public abstract event UserServerTickedDelegate OnServerTicked;
+
+        /// <summary>
+        /// This event will be invoked when a server tick has failed.
+        /// </summary>
+        public abstract event ServerTickFailedDelegate OnServerTickFailed;
 
         /// <summary>
         /// Constructs a generalised synchronizer object

--- a/ElectrodZMultiplayer/Core/Data/Messages/ServerTickFailedMessageData.cs
+++ b/ElectrodZMultiplayer/Core/Data/Messages/ServerTickFailedMessageData.cs
@@ -1,0 +1,43 @@
+﻿using Newtonsoft.Json;
+using System;
+
+/// <summary>
+/// ElectrodZ multiplayer data messages namespace
+/// </summary>
+namespace ElectrodZMultiplayer.Data.Messages
+{
+    /// <summary>
+    /// A class that describes a server tick failed message
+    /// </summary>
+    [JsonObject(MemberSerialization.OptIn)]
+    internal class ServerTickFailedMessageData : BaseFailedMessageData<ServerTickMessageData, EServerTickFailedReason>
+    {
+        /// <summary>
+        /// Is object in a valid state
+        /// </summary>
+        public override bool IsValid =>
+            base.IsValid &&
+            (Reason != EServerTickFailedReason.Invalid);
+
+        /// <summary>
+        /// Constructs a server tick failed message for deserializers
+        /// </summary>
+        public ServerTickFailedMessageData() : base()
+        {
+            // ...
+        }
+
+        /// <summary>
+        /// Constructs a server tick failed message
+        /// </summary>
+        /// <param name="message">Message</param>
+        /// <param name="reason">Reason</param>
+        public ServerTickFailedMessageData(ServerTickMessageData message, EServerTickFailedReason reason) : base(Naming.GetMessageTypeNameFromMessageDataType<ServerTickFailedMessageData>(), message, reason)
+        {
+            if (reason == EServerTickFailedReason.Invalid)
+            {
+                throw new ArgumentException("Server tick failed reason can't be invalid.", nameof(reason));
+            }
+        }
+    }
+}

--- a/ElectrodZMultiplayer/Core/Data/Messages/ServerTickMessageData.cs
+++ b/ElectrodZMultiplayer/Core/Data/Messages/ServerTickMessageData.cs
@@ -11,7 +11,7 @@ namespace ElectrodZMultiplayer.Data.Messages
     /// A class that describes a server tick message
     /// </summary>
     [JsonObject(MemberSerialization.OptIn)]
-    internal class ServerTickMessageData : BaseMessageData
+    public class ServerTickMessageData : BaseMessageData
     {
         /// <summary>
         /// Elapsed time in seconds since game start

--- a/ElectrodZMultiplayer/Core/Delegates/LobbyGameRestartRequestedDelegate.cs
+++ b/ElectrodZMultiplayer/Core/Delegates/LobbyGameRestartRequestedDelegate.cs
@@ -1,0 +1,12 @@
+﻿/// <summary>
+/// ElectrodZ multiplayer namespace
+/// </summary>
+namespace ElectrodZMultiplayer
+{
+    /// <summary>
+    /// Used to signal a request to restart a game
+    /// </summary>
+    /// <param name="lobby">Lobby</param>
+    /// <param name="time">Time to restart game in seconds</param>
+    public delegate void LobbyGameRestartRequestedDelegate(ILobby lobby, double time);
+}

--- a/ElectrodZMultiplayer/Core/Delegates/LobbyGameRestartedDelegate.cs
+++ b/ElectrodZMultiplayer/Core/Delegates/LobbyGameRestartedDelegate.cs
@@ -1,0 +1,11 @@
+﻿/// <summary>
+/// ElectrodZ multiplayer namespace
+/// </summary>
+namespace ElectrodZMultiplayer
+{
+    /// <summary>
+    /// Used to signal game being restarted
+    /// </summary>
+    /// <param name="lobby">Lobby</param>
+    public delegate void LobbyGameRestartedDelegate(ILobby lobby);
+}

--- a/ElectrodZMultiplayer/Core/Delegates/LobbyGameStartRequestedDelegate.cs
+++ b/ElectrodZMultiplayer/Core/Delegates/LobbyGameStartRequestedDelegate.cs
@@ -1,0 +1,12 @@
+﻿/// <summary>
+/// ElectrodZ multiplayer namespace
+/// </summary>
+namespace ElectrodZMultiplayer
+{
+    /// <summary>
+    /// Used to signal a game start request
+    /// </summary>
+    /// <param name="lobby">Lobby</param>
+    /// <param name="time">Time to start game in seconds</param>
+    public delegate void LobbyGameStartRequestedDelegate(ILobby lobby, double time);
+}

--- a/ElectrodZMultiplayer/Core/Delegates/LobbyGameStartedDelegate.cs
+++ b/ElectrodZMultiplayer/Core/Delegates/LobbyGameStartedDelegate.cs
@@ -1,0 +1,11 @@
+﻿/// <summary>
+/// ElectrodZ multiplayer namespace
+/// </summary>
+namespace ElectrodZMultiplayer
+{
+    /// <summary>
+    /// Used to signal a game being started
+    /// </summary>
+    /// <param name="lobby">Lobby</param>
+    public delegate void LobbyGameStartedDelegate(ILobby lobby);
+}

--- a/ElectrodZMultiplayer/Core/Delegates/LobbyGameStopRequestedDelegate.cs
+++ b/ElectrodZMultiplayer/Core/Delegates/LobbyGameStopRequestedDelegate.cs
@@ -1,0 +1,12 @@
+﻿/// <summary>
+/// ElectrodZ multiplayer namespace
+/// </summary>
+namespace ElectrodZMultiplayer
+{
+    /// <summary>
+    /// Used to signal a game stop request
+    /// </summary>
+    /// <param name="lobby">Lobby</param>
+    /// <param name="time">Time to stop game in seconds</param>
+    public delegate void LobbyGameStopRequestedDelegate(ILobby lobby, double time);
+}

--- a/ElectrodZMultiplayer/Core/Delegates/LobbyGameStoppedDelegate.cs
+++ b/ElectrodZMultiplayer/Core/Delegates/LobbyGameStoppedDelegate.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+
+/// <summary>
+/// ElectrodZ multiplayer namespace
+/// </summary>
+namespace ElectrodZMultiplayer
+{
+    /// <summary>
+    /// Used to signal a game being stopped
+    /// </summary>
+    /// <param name="lobby">Lobby</param>
+    /// <param name="users">Participating users</param>
+    /// <param name="results">Game end results</param>
+    public delegate void LobbyGameStoppedDelegate(ILobby lobby, IReadOnlyDictionary<string, UserWithResults> users, IReadOnlyDictionary<string, object> results);
+}

--- a/ElectrodZMultiplayer/Core/Delegates/LobbyLobbyRulesUpdatedDelegate.cs
+++ b/ElectrodZMultiplayer/Core/Delegates/LobbyLobbyRulesUpdatedDelegate.cs
@@ -1,0 +1,11 @@
+﻿/// <summary>
+/// ElectrodZ multiplayer namespace
+/// </summary>
+namespace ElectrodZMultiplayer
+{
+    /// <summary>
+    /// Used to signal lobby rules being updated
+    /// </summary>
+    /// <param name="lobby">Lobby</param>
+    public delegate void LobbyLobbyRulesUpdatedDelegate(ILobby lobby);
+}

--- a/ElectrodZMultiplayer/Core/Delegates/LobbyUserJoinedDelegate.cs
+++ b/ElectrodZMultiplayer/Core/Delegates/LobbyUserJoinedDelegate.cs
@@ -1,0 +1,12 @@
+﻿/// <summary>
+/// ElectrodZ multiplayer namespace
+/// </summary>
+namespace ElectrodZMultiplayer
+{
+    /// <summary>
+    /// Used to signal an user joining a lobby
+    /// </summary>
+    /// <param name="lobby">Lobby</param>
+    /// <param name="user">Joining user</param>
+    public delegate void LobbyUserJoinedDelegate(ILobby lobby, IUser user);
+}

--- a/ElectrodZMultiplayer/Core/Delegates/LobbyUserLeftDelegate.cs
+++ b/ElectrodZMultiplayer/Core/Delegates/LobbyUserLeftDelegate.cs
@@ -1,0 +1,14 @@
+﻿/// <summary>
+/// ElectrodZ multiplayer namespace
+/// </summary>
+namespace ElectrodZMultiplayer
+{
+    /// <summary>
+    /// Used to signal an user leaving the lobby
+    /// </summary>
+    /// <param name="lobby">Lobby</param>
+    /// <param name="user">Leaving user</param>
+    /// <param name="reason">Reason to leave</param>
+    /// <param name="message">Leave message</param>
+    public delegate void LobbyUserLeftDelegate(ILobby lobby, IUser user, EDisconnectionReason reason, string message);
+}

--- a/ElectrodZMultiplayer/Core/Delegates/ServerTickFailedDelegate.cs
+++ b/ElectrodZMultiplayer/Core/Delegates/ServerTickFailedDelegate.cs
@@ -1,0 +1,15 @@
+﻿using ElectrodZMultiplayer.Data.Messages;
+
+/// <summary>
+/// ElectrodZ multiplayer namespace
+/// </summary>
+namespace ElectrodZMultiplayer
+{
+    /// <summary>
+    /// This is being used to signal when a server tick has failed
+    /// </summary>
+    /// <param name="peer">Peer</param>
+    /// <param name="message">Received message</param>
+    /// <param name="reason">Reason</param>
+    public delegate void ServerTickFailedDelegate(IPeer peer, ServerTickMessageData message, EServerTickFailedReason reason);
+}

--- a/ElectrodZMultiplayer/Core/Delegates/UserClientTickedDelegate.cs
+++ b/ElectrodZMultiplayer/Core/Delegates/UserClientTickedDelegate.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+
+/// <summary>
+/// ElectrodZ multiplayer namespace
+/// </summary>
+namespace ElectrodZMultiplayer
+{
+    /// <summary>
+    /// Used to signal a client tick
+    /// </summary>
+    /// <param name="user">user</param>
+    /// <param name="entityDeltas">Entity deltas</param>
+    public delegate void UserClientTickedDelegate(IUser user, IEnumerable<IEntityDelta> entityDeltas);
+}

--- a/ElectrodZMultiplayer/Core/Delegates/UserServerTickedDelegate.cs
+++ b/ElectrodZMultiplayer/Core/Delegates/UserServerTickedDelegate.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+
+/// <summary>
+/// ElectrodZ multiplayer namespace
+/// </summary>
+namespace ElectrodZMultiplayer
+{
+    /// <summary>
+    /// Used to signal a server tick
+    /// </summary>
+    /// <param name="user">User</param>
+    /// <param name="time">Elapsed time in seconds since game start</param>
+    /// <param name="entityDeltas">Entity deltas</param>>
+    public delegate void UserServerTickedDelegate(IUser user, double time, IEnumerable<IEntityDelta> entityDeltas);
+}

--- a/ElectrodZMultiplayer/Core/Delegates/UserUserLobbyColorUpdatedDelegate.cs
+++ b/ElectrodZMultiplayer/Core/Delegates/UserUserLobbyColorUpdatedDelegate.cs
@@ -1,0 +1,11 @@
+﻿/// <summary>
+/// ElectrodZ multiplayer namespace
+/// </summary>
+namespace ElectrodZMultiplayer
+{
+    /// <summary>
+    /// Used to signal user lobby color being updated
+    /// </summary>
+    /// <param name="user">User</param>
+    public delegate void UserUserLobbyColorUpdatedDelegate(IUser user);
+}

--- a/ElectrodZMultiplayer/Core/Delegates/UserUsernameUpdatedDelegate.cs
+++ b/ElectrodZMultiplayer/Core/Delegates/UserUsernameUpdatedDelegate.cs
@@ -1,0 +1,11 @@
+﻿/// <summary>
+/// ElectrodZ multiplayer namespace
+/// </summary>
+namespace ElectrodZMultiplayer
+{
+    /// <summary>
+    /// Used to signal an username being updated
+    /// </summary>
+    /// <param name="user">User</param>
+    public delegate void UserUsernameUpdatedDelegate(IUser user);
+}

--- a/ElectrodZMultiplayer/Core/Enumerators/EServerTickFailedReason.cs
+++ b/ElectrodZMultiplayer/Core/Enumerators/EServerTickFailedReason.cs
@@ -1,0 +1,25 @@
+﻿using ElectrodZMultiplayer.JSONConverters;
+using Newtonsoft.Json;
+
+/// <summary>
+/// ElectrodZ multiplayer namespace
+/// </summary>
+namespace ElectrodZMultiplayer
+{
+    /// <summary>
+    /// Server tick failed reason enumerator
+    /// </summary>
+    [JsonConverter(typeof(ServerTickFailedReasonJSONConverter))]
+    public enum EServerTickFailedReason
+    {
+        /// <summary>
+        /// Invalid
+        /// </summary>
+        Invalid,
+
+        /// <summary>
+        /// Unknown reason
+        /// </summary>
+        Unknown
+    }
+}

--- a/ElectrodZMultiplayer/Core/Interfaces/ISynchronizer.cs
+++ b/ElectrodZMultiplayer/Core/Interfaces/ISynchronizer.cs
@@ -77,6 +77,11 @@ namespace ElectrodZMultiplayer
         event ListAvailableGameModesFailedDelegate OnListAvailableGameModesFailed;
 
         /// <summary>
+        /// This event will be invoked when an user has joined this lobby.
+        /// </summary>
+        event LobbyUserJoinedDelegate OnUserJoined;
+
+        /// <summary>
         /// This event will be invoked when joining a lobby has failed.
         /// </summary>
         event JoinLobbyFailedDelegate OnJoinLobbyFailed;
@@ -87,14 +92,34 @@ namespace ElectrodZMultiplayer
         event CreateLobbyFailedDelegate OnCreateLobbyFailed;
 
         /// <summary>
+        /// This event will be invoked when an user left this lobby.
+        /// </summary>
+        event LobbyUserLeftDelegate OnUserLeft;
+
+        /// <summary>
+        /// This event will be invoked when the username changes.
+        /// </summary>
+        event UserUsernameUpdatedDelegate OnUsernameUpdated;
+
+        /// <summary>
         /// This event will be invoked when changing username has failed.
         /// </summary>
         event ChangeUsernameFailedDelegate OnChangeUsernameFailed;
 
         /// <summary>
+        /// This event will be invoked when the user lobby color changes.
+        /// </summary>
+        event UserUserLobbyColorUpdatedDelegate OnUserLobbyColorUpdated;
+
+        /// <summary>
         /// This event will be invoked when changing user lobby color has failed.
         /// </summary>
         event ChangeUserLobbyColorFailedDelegate OnChangeUserLobbyColorFailed;
+
+        /// <summary>
+        /// This event will be invoked when the lobby rules of this lobby has been updated.
+        /// </summary>
+        event LobbyLobbyRulesUpdatedDelegate OnLobbyRulesUpdated;
 
         /// <summary>
         /// This event will be invoked when changing lobby rules have failed.
@@ -107,9 +132,29 @@ namespace ElectrodZMultiplayer
         event KickUserFailedDelegate OnKickUserFailed;
 
         /// <summary>
+        /// This event will be invoked when a game has been started.
+        /// </summary>
+        event LobbyGameStartedDelegate OnGameStarted;
+
+        /// <summary>
+        /// This event will be invoked when a game start has been requested.
+        /// </summary>
+        event LobbyGameStartRequestedDelegate OnGameStartRequested;
+
+        /// <summary>
         /// This event will be invoked when starting a game has failed.
         /// </summary>
         event StartGameFailedDelegate OnStartGameFailed;
+
+        /// <summary>
+        /// This event will be invoked when a game has been restarted.
+        /// </summary>
+        event LobbyGameRestartedDelegate OnGameRestarted;
+
+        /// <summary>
+        /// This event will be invoked when a game restart has been requested.
+        /// </summary>
+        event LobbyGameRestartRequestedDelegate OnGameRestartRequested;
 
         /// <summary>
         /// This event will be invoked when restarting a game has failed.
@@ -117,14 +162,39 @@ namespace ElectrodZMultiplayer
         event RestartGameFailedDelegate OnRestartGameFailed;
 
         /// <summary>
+        /// This event will be invoked when a game has been stopped.
+        /// </summary>
+        event LobbyGameStoppedDelegate OnGameStopped;
+
+        /// <summary>
+        /// This event will be invoked when a game stop has been requested.
+        /// </summary>
+        event LobbyGameStopRequestedDelegate OnGameStopRequested;
+
+        /// <summary>
         /// This event will be invoked when stopping a game has failed.
         /// </summary>
         event StopGameFailedDelegate OnStopGameFailed;
 
         /// <summary>
+        /// This event will be invoked when a client tick has been performed.
+        /// </summary>
+        event UserClientTickedDelegate OnClientTicked;
+
+        /// <summary>
         /// This event will be invoked when a client tick has failed.
         /// </summary>
         event ClientTickFailedDelegate OnClientTickFailed;
+
+        /// <summary>
+        /// This event will be invoked when a server tick has been performed.
+        /// </summary>
+        event UserServerTickedDelegate OnServerTicked;
+
+        /// <summary>
+        /// This event will be invoked when a server tick has failed.
+        /// </summary>
+        event ServerTickFailedDelegate OnServerTickFailed;
 
         /// <summary>
         /// Add connector

--- a/ElectrodZMultiplayer/Core/JSONConverters/ServerTickFailedReasonJSONConverter.cs
+++ b/ElectrodZMultiplayer/Core/JSONConverters/ServerTickFailedReasonJSONConverter.cs
@@ -1,0 +1,19 @@
+﻿/// <summary>
+/// ElectrodZ multiplayer JSON converters namespace
+/// </summary>
+namespace ElectrodZMultiplayer.JSONConverters
+{
+    /// <summary>
+    /// A class used for converting server tick failed reason to JSON and vice versa
+    /// </summary>
+    internal class ServerTickFailedReasonJSONConverter : EnumeratorValueJSONConverter<EServerTickFailedReason>
+    {
+        /// <summary>
+        /// Constructs a server tick failed reason JSON converter
+        /// </summary>
+        public ServerTickFailedReasonJSONConverter() : base(EServerTickFailedReason.Invalid)
+        {
+            // ...
+        }
+    }
+}


### PR DESCRIPTION
This pull request contains patches to the current events in synchronizers, which adds repeating events found in lobbies and users and additionally adds the server tick failed message, which was missing from the previous pull request.