### PR TITLE
User entity and non-user entity events

### DIFF
--- a/ElectrodZMultiplayer/Client/Misc/ClientSynchronizer.cs
+++ b/ElectrodZMultiplayer/Client/Misc/ClientSynchronizer.cs
@@ -231,6 +231,36 @@ namespace ElectrodZMultiplayer.Client
         public override event ServerTickFailedDelegate OnServerTickFailed;
 
         /// <summary>
+        /// This event will be invoked when an user entity has been created.
+        /// </summary>
+        public override event LobbyUserEntityCreatedDelegate OnUserEntityCreated;
+
+        /// <summary>
+        /// This event will be invoked when an user entity has been updated.
+        /// </summary>
+        public override event LobbyUserEntityUpdatedDelegate OnUserEntityUpdated;
+
+        /// <summary>
+        /// This event will be invoked when an user entity has been destroyed.
+        /// </summary>
+        public override event LobbyUserEntityDestroyedDelegate OnUserEntityDestroyed;
+
+        /// <summary>
+        /// This event will be invoked when an entity has been created.
+        /// </summary>
+        public override event LobbyEntityCreatedDelegate OnEntityCreated;
+
+        /// <summary>
+        /// This event will be invoked when an entity has been updated.
+        /// </summary>
+        public override event LobbyEntityUpdatedDelegate OnEntityUpdated;
+
+        /// <summary>
+        /// This event will be invoked when an entity has been destroyed.
+        /// </summary>
+        public override event LobbyEntityDestroyedDelegate OnEntityDestroyed;
+
+        /// <summary>
         /// Constructor
         /// </summary>
         /// <param name="peer">Peer</param>
@@ -309,6 +339,12 @@ namespace ElectrodZMultiplayer.Client
                             client_lobby.OnStartGameCancelled += () => OnStartGameCancelled?.Invoke(client_lobby);
                             client_lobby.OnRestartGameCancelled += () => OnRestartGameCancelled?.Invoke(client_lobby);
                             client_lobby.OnStopGameCancelled += () => OnStopGameCancelled?.Invoke(client_lobby);
+                            client_lobby.OnUserEntityCreated += (user) => OnUserEntityCreated?.Invoke(client_lobby, user);
+                            client_lobby.OnUserEntityUpdated += (user) => OnUserEntityUpdated?.Invoke(client_lobby, user);
+                            client_lobby.OnUserEntityDestroyed += (user) => OnUserEntityDestroyed?.Invoke(client_lobby, user);
+                            client_lobby.OnEntityCreated += (entity) => OnEntityCreated?.Invoke(client_lobby, entity);
+                            client_lobby.OnEntityUpdated += (entity) => OnEntityUpdated?.Invoke(client_lobby, entity);
+                            client_lobby.OnEntityDestroyed += (entity) => OnEntityDestroyed?.Invoke(client_lobby, entity);
                             user.ClientLobby = client_lobby;
                             foreach (IInternalClientUser client_user in user_list)
                             {

--- a/ElectrodZMultiplayer/Core/Abstract/ASynchronizer.cs
+++ b/ElectrodZMultiplayer/Core/Abstract/ASynchronizer.cs
@@ -240,6 +240,36 @@ namespace ElectrodZMultiplayer
         public abstract event ServerTickFailedDelegate OnServerTickFailed;
 
         /// <summary>
+        /// This event will be invoked when an user entity has been created.
+        /// </summary>
+        public abstract event LobbyUserEntityCreatedDelegate OnUserEntityCreated;
+
+        /// <summary>
+        /// This event will be invoked when an user entity has been updated.
+        /// </summary>
+        public abstract event LobbyUserEntityUpdatedDelegate OnUserEntityUpdated;
+
+        /// <summary>
+        /// This event will be invoked when an user entity has been destroyed.
+        /// </summary>
+        public abstract event LobbyUserEntityDestroyedDelegate OnUserEntityDestroyed;
+
+        /// <summary>
+        /// This event will be invoked when an entity has been created.
+        /// </summary>
+        public abstract event LobbyEntityCreatedDelegate OnEntityCreated;
+
+        /// <summary>
+        /// This event will be invoked when an entity has been updated.
+        /// </summary>
+        public abstract event LobbyEntityUpdatedDelegate OnEntityUpdated;
+
+        /// <summary>
+        /// This event will be invoked when an entity has been destroyed.
+        /// </summary>
+        public abstract event LobbyEntityDestroyedDelegate OnEntityDestroyed;
+
+        /// <summary>
         /// Constructs a generalised synchronizer object
         /// </summary>
         public ASynchronizer() =>

--- a/ElectrodZMultiplayer/Core/Data/EntityData.cs
+++ b/ElectrodZMultiplayer/Core/Data/EntityData.cs
@@ -130,6 +130,10 @@ namespace ElectrodZMultiplayer.Data
             {
                 throw new ArgumentNullException(nameof(entity));
             }
+            if (!entity.IsValid)
+            {
+                throw new ArgumentException("Entity is not valid.", nameof(entity));
+            }
             return new EntityDelta
             (
                 entity.GUID,

--- a/ElectrodZMultiplayer/Core/Delegates/LobbyEntityCreatedDelegate.cs
+++ b/ElectrodZMultiplayer/Core/Delegates/LobbyEntityCreatedDelegate.cs
@@ -1,0 +1,12 @@
+﻿/// <summary>
+/// ElectrodZ multiplayer namespace
+/// </summary>
+namespace ElectrodZMultiplayer
+{
+    /// <summary>
+    /// Used to signal when an entity has been created in an entity streamer
+    /// </summary>
+    /// <param name="lobby">Lobby</param>
+    /// <param name="entity">Entity</param>
+    public delegate void LobbyEntityCreatedDelegate(ILobby lobby, IEntity entity);
+}

--- a/ElectrodZMultiplayer/Core/Delegates/LobbyEntityDestroyedDelegate.cs
+++ b/ElectrodZMultiplayer/Core/Delegates/LobbyEntityDestroyedDelegate.cs
@@ -1,0 +1,12 @@
+﻿/// <summary>
+/// ElectrodZ multiplayer namespace
+/// </summary>
+namespace ElectrodZMultiplayer
+{
+    /// <summary>
+    /// Used to signal when an entity has been destroyed in an entity streamer
+    /// </summary>
+    /// <param name="lobby">Lobby</param>
+    /// <param name="entity">Entity</param>
+    public delegate void LobbyEntityDestroyedDelegate(ILobby lobby, IEntity entity);
+}

--- a/ElectrodZMultiplayer/Core/Delegates/LobbyEntityUpdatedDelegate.cs
+++ b/ElectrodZMultiplayer/Core/Delegates/LobbyEntityUpdatedDelegate.cs
@@ -1,0 +1,12 @@
+﻿/// <summary>
+/// ElectrodZ multiplayer namespace
+/// </summary>
+namespace ElectrodZMultiplayer
+{
+    /// <summary>
+    /// Used to signal when an entity has been updated in an entity streamer
+    /// </summary>
+    /// <param name="lobby">Lobby</param>
+    /// <param name="entity">Entity</param>
+    public delegate void LobbyEntityUpdatedDelegate(ILobby lobby, IEntity entity);
+}

--- a/ElectrodZMultiplayer/Core/Delegates/LobbyUserEntityCreatedDelegate.cs
+++ b/ElectrodZMultiplayer/Core/Delegates/LobbyUserEntityCreatedDelegate.cs
@@ -1,0 +1,12 @@
+﻿/// <summary>
+/// ElectrodZ multiplayer namespace
+/// </summary>
+namespace ElectrodZMultiplayer
+{
+    /// <summary>
+    /// Used to signal when an user entity has been created in an entity streamer
+    /// </summary>
+    /// <param name="lobby">Lobby</param>
+    /// <param name="user">User</param>
+    public delegate void LobbyUserEntityCreatedDelegate(ILobby lobby, IUser user);
+}

--- a/ElectrodZMultiplayer/Core/Delegates/LobbyUserEntityDestroyedDelegate.cs
+++ b/ElectrodZMultiplayer/Core/Delegates/LobbyUserEntityDestroyedDelegate.cs
@@ -1,0 +1,12 @@
+﻿/// <summary>
+/// ElectrodZ multiplayer namespace
+/// </summary>
+namespace ElectrodZMultiplayer
+{
+    /// <summary>
+    /// Used to signal when an user entity has been destroyed in an entity streamer
+    /// </summary>
+    /// <param name="lobby">Lobby</param>
+    /// <param name="user">User</param>
+    public delegate void LobbyUserEntityDestroyedDelegate(ILobby lobby, IUser user);
+}

--- a/ElectrodZMultiplayer/Core/Delegates/LobbyUserEntityUpdatedDelegate.cs
+++ b/ElectrodZMultiplayer/Core/Delegates/LobbyUserEntityUpdatedDelegate.cs
@@ -1,0 +1,12 @@
+﻿/// <summary>
+/// ElectrodZ multiplayer namespace
+/// </summary>
+namespace ElectrodZMultiplayer
+{
+    /// <summary>
+    /// Used to signal when an user entity has been updated in an entity streamer
+    /// </summary>
+    /// <param name="lobby">Lobby</param>
+    /// <param name="user">User</param>
+    public delegate void LobbyUserEntityUpdatedDelegate(ILobby lobby, IUser user);
+}

--- a/ElectrodZMultiplayer/Core/Delegates/UserEntityCreatedDelegate.cs
+++ b/ElectrodZMultiplayer/Core/Delegates/UserEntityCreatedDelegate.cs
@@ -1,0 +1,11 @@
+﻿/// <summary>
+/// ElectrodZ multiplayer namespace
+/// </summary>
+namespace ElectrodZMultiplayer
+{
+    /// <summary>
+    /// Used to signal when an user entity has been created in an entity streamer
+    /// </summary>
+    /// <param name="user">User</param>
+    public delegate void UserEntityCreatedDelegate(IUser user);
+}

--- a/ElectrodZMultiplayer/Core/Delegates/UserEntityDestroyedDelegate.cs
+++ b/ElectrodZMultiplayer/Core/Delegates/UserEntityDestroyedDelegate.cs
@@ -1,0 +1,11 @@
+﻿/// <summary>
+/// ElectrodZ multiplayer namespace
+/// </summary>
+namespace ElectrodZMultiplayer
+{
+    /// <summary>
+    /// Used to signal when an user entity has been destroyed in an entity streamer
+    /// </summary>
+    /// <param name="user">User</param>
+    public delegate void UserEntityDestroyedDelegate(IUser user);
+}

--- a/ElectrodZMultiplayer/Core/Delegates/UserEntityUpdatedDelegate.cs
+++ b/ElectrodZMultiplayer/Core/Delegates/UserEntityUpdatedDelegate.cs
@@ -1,0 +1,11 @@
+﻿/// <summary>
+/// ElectrodZ multiplayer namespace
+/// </summary>
+namespace ElectrodZMultiplayer
+{
+    /// <summary>
+    /// Used to signal when an user entity has been updated in an entity streamer
+    /// </summary>
+    /// <param name="user">User</param>
+    public delegate void UserEntityUpdatedDelegate(IUser user);
+}

--- a/ElectrodZMultiplayer/Core/Interfaces/ILobby.cs
+++ b/ElectrodZMultiplayer/Core/Interfaces/ILobby.cs
@@ -97,6 +97,36 @@ namespace ElectrodZMultiplayer
         event StopGameCancelledDelegate OnStopGameCancelled;
 
         /// <summary>
+        /// This event will be invoked when an user entity has been created.
+        /// </summary>
+        event UserEntityCreatedDelegate OnUserEntityCreated;
+
+        /// <summary>
+        /// This event will be invoked when an user entity has been updated.
+        /// </summary>
+        event UserEntityUpdatedDelegate OnUserEntityUpdated;
+
+        /// <summary>
+        /// This event will be invoked when an user entity has been destroyed.
+        /// </summary>
+        event UserEntityDestroyedDelegate OnUserEntityDestroyed;
+
+        /// <summary>
+        /// This event will be invoked when an entity has been created.
+        /// </summary>
+        event EntityCreatedDelegate OnEntityCreated;
+
+        /// <summary>
+        /// This event will be invoked when an entity has been updated.
+        /// </summary>
+        event EntityUpdatedDelegate OnEntityUpdated;
+
+        /// <summary>
+        /// This event will be invoked when an entity has been destroyed.
+        /// </summary>
+        event EntityDestroyedDelegate OnEntityDestroyed;
+
+        /// <summary>
         /// Gets user by GUID
         /// </summary>
         /// <param name="guid">User GUID</param>

--- a/ElectrodZMultiplayer/Core/Interfaces/ISynchronizer.cs
+++ b/ElectrodZMultiplayer/Core/Interfaces/ISynchronizer.cs
@@ -227,6 +227,36 @@ namespace ElectrodZMultiplayer
         event ServerTickFailedDelegate OnServerTickFailed;
 
         /// <summary>
+        /// This event will be invoked when an user entity has been created.
+        /// </summary>
+        event LobbyUserEntityCreatedDelegate OnUserEntityCreated;
+
+        /// <summary>
+        /// This event will be invoked when an user entity has been updated.
+        /// </summary>
+        event LobbyUserEntityUpdatedDelegate OnUserEntityUpdated;
+
+        /// <summary>
+        /// This event will be invoked when an user entity has been destroyed.
+        /// </summary>
+        event LobbyUserEntityDestroyedDelegate OnUserEntityDestroyed;
+
+        /// <summary>
+        /// This event will be invoked when an entity has been created.
+        /// </summary>
+        event LobbyEntityCreatedDelegate OnEntityCreated;
+
+        /// <summary>
+        /// This event will be invoked when an entity has been updated.
+        /// </summary>
+        event LobbyEntityUpdatedDelegate OnEntityUpdated;
+
+        /// <summary>
+        /// This event will be invoked when an entity has been destroyed.
+        /// </summary>
+        event LobbyEntityDestroyedDelegate OnEntityDestroyed;
+
+        /// <summary>
         /// Add connector
         /// </summary>
         /// <param name="connector">Connector</param>

--- a/ElectrodZMultiplayer/Core/Misc/Entity.cs
+++ b/ElectrodZMultiplayer/Core/Misc/Entity.cs
@@ -63,7 +63,9 @@ namespace ElectrodZMultiplayer
         /// <returns>"true" if valid, otherwise "false"</returns>
         public bool IsValid =>
             (GUID != Guid.Empty) &&
-            (GameColor != EGameColor.Invalid);
+            !string.IsNullOrWhiteSpace(EntityType) &&
+            (GameColor != EGameColor.Invalid) &&
+            Protection.IsValid(Actions);
 
         /// <summary>
         /// Constructs an entity object
@@ -82,6 +84,48 @@ namespace ElectrodZMultiplayer
             }
             GUID = guid;
             EntityType = entityType;
+        }
+
+        /// <summary>
+        /// Constructs an entity object
+        /// </summary>
+        /// <param name="guid">Entity GUID</param>
+        /// <param name="entityType">Entity type</param>
+        /// <param name="gameColor">Game color</param>
+        /// <param name="position">Position</param>
+        /// <param name="rotation">Rotation</param>
+        /// <param name="velocity">Velocity</param>
+        /// <param name="angularVelocity">Angular velocity</param>
+        /// <param name="actions">Game actions</param>
+        public Entity(Guid guid, string entityType, EGameColor gameColor, Vector3 position, Quaternion rotation, Vector3 velocity, Vector3 angularVelocity, IEnumerable<string> actions)
+        {
+            if (guid == Guid.Empty)
+            {
+                throw new ArgumentException("Entity GUID can't be empty.", nameof(guid));
+            }
+            if (string.IsNullOrWhiteSpace(entityType))
+            {
+                throw new ArgumentNullException(nameof(entityType));
+            }
+            if (gameColor == EGameColor.Invalid)
+            {
+                throw new ArgumentException("Game color can't be invalid.", nameof(gameColor));
+            }
+            if (actions == null)
+            {
+                throw new ArgumentNullException(nameof(actions));
+            }
+            if (Protection.IsContained(actions, (action) => action == null))
+            {
+                throw new ArgumentException($"\"{ nameof(actions) }\" contains invalid game actions.", nameof(guid));
+            }
+            GUID = guid;
+            EntityType = entityType;
+            GameColor = gameColor;
+            Position = position;
+            Rotation = rotation;
+            Velocity = velocity;
+            AngularVelocity = angularVelocity;
         }
 
         /// <summary>
@@ -191,48 +235,6 @@ namespace ElectrodZMultiplayer
         }
 
         /// <summary>
-        /// Constructs an entity object
-        /// </summary>
-        /// <param name="guid">Entity GUID</param>
-        /// <param name="entityType">Entity type</param>
-        /// <param name="gameColor">Game color</param>
-        /// <param name="position">Position</param>
-        /// <param name="rotation">Rotation</param>
-        /// <param name="velocity">Velocity</param>
-        /// <param name="angularVelocity">Angular velocity</param>
-        /// <param name="actions">Game actions</param>
-        public Entity(Guid guid, string entityType, EGameColor gameColor, Vector3 position, Quaternion rotation, Vector3 velocity, Vector3 angularVelocity, IEnumerable<string> actions)
-        {
-            if (guid == Guid.Empty)
-            {
-                throw new ArgumentException("Entity GUID can't be empty.", nameof(guid));
-            }
-            if (string.IsNullOrWhiteSpace(entityType))
-            {
-                throw new ArgumentNullException(nameof(entityType));
-            }
-            if (gameColor == EGameColor.Invalid)
-            {
-                throw new ArgumentException("Game color can't be invalid.", nameof(gameColor));
-            }
-            if (actions == null)
-            {
-                throw new ArgumentNullException(nameof(actions));
-            }
-            if (Protection.IsContained(actions, (action) => action == null))
-            {
-                throw new ArgumentException($"\"{ nameof(actions) }\" contains invalid game actions.", nameof(guid));
-            }
-            GUID = guid;
-            EntityType = entityType;
-            GameColor = gameColor;
-            Position = position;
-            Rotation = rotation;
-            Velocity = velocity;
-            AngularVelocity = angularVelocity;
-        }
-
-        /// <summary>
         /// Sets a new entity GUID internally
         /// </summary>
         /// <param name="guid">New entity GUID</param>
@@ -332,6 +334,10 @@ namespace ElectrodZMultiplayer
             if (!entity.IsValid)
             {
                 throw new ArgumentException("Entity is not valid.", nameof(entity));
+            }
+            if (string.IsNullOrWhiteSpace(entity.EntityType))
+            {
+                throw new ArgumentException("Entity type can't be empty.", nameof(entity));
             }
             return new Entity(entity.GUID, entity.EntityType, (entity.GameColor == null) ? EGameColor.Default : entity.GameColor.Value, (entity.Position == null) ? Vector3.Zero : new Vector3(entity.Position.X, entity.Position.Y, entity.Position.Z), (entity.Rotation == null) ? Quaternion.Identity : new Quaternion(entity.Rotation.X, entity.Rotation.Y, entity.Rotation.Z, entity.Rotation.W), (entity.Velocity == null) ? Vector3.Zero : new Vector3(entity.Velocity.X, entity.Velocity.Y, entity.Velocity.Z), (entity.AngularVelocity == null) ? Vector3.Zero : new Vector3(entity.AngularVelocity.X, entity.AngularVelocity.Y, entity.AngularVelocity.Z), entity.Actions ?? (IEnumerable<string>)Array.Empty<string>());
         }

--- a/ElectrodZMultiplayer/Core/Misc/EntityStreamer.cs
+++ b/ElectrodZMultiplayer/Core/Misc/EntityStreamer.cs
@@ -40,7 +40,7 @@ namespace ElectrodZMultiplayer
         /// Gets the delta for the specified entity
         /// </summary>
         /// <param name="entity">Entity</param>
-        /// <returns></returns>
+        /// <returns>Entity delta</returns>
         private IEntityDelta GetEntityDelta(IEntity entity)
         {
             IEntityDelta ret;
@@ -50,7 +50,7 @@ namespace ElectrodZMultiplayer
                 (Entity, IEntityDelta) base_entity = entities[key];
                 if (Entity.TryGetDelta(base_entity.Item1, entity, out ret))
                 {
-                    if (ret.EntityType != null)
+                    if (!string.IsNullOrWhiteSpace(ret.EntityType))
                     {
                         base_entity.Item1.SetEntityTypeInternally(ret.EntityType);
                     }

--- a/ElectrodZMultiplayer/Server/Misc/ServerSynchronizer.cs
+++ b/ElectrodZMultiplayer/Server/Misc/ServerSynchronizer.cs
@@ -271,6 +271,36 @@ namespace ElectrodZMultiplayer.Server
         public override event ServerTickFailedDelegate OnServerTickFailed;
 
         /// <summary>
+        /// This event will be invoked when an user entity has been created.
+        /// </summary>
+        public override event LobbyUserEntityCreatedDelegate OnUserEntityCreated;
+
+        /// <summary>
+        /// This event will be invoked when an user entity has been updated.
+        /// </summary>
+        public override event LobbyUserEntityUpdatedDelegate OnUserEntityUpdated;
+
+        /// <summary>
+        /// This event will be invoked when an user entity has been destroyed.
+        /// </summary>
+        public override event LobbyUserEntityDestroyedDelegate OnUserEntityDestroyed;
+
+        /// <summary>
+        /// This event will be invoked when an entity has been created.
+        /// </summary>
+        public override event LobbyEntityCreatedDelegate OnEntityCreated;
+
+        /// <summary>
+        /// This event will be invoked when an entity has been updated.
+        /// </summary>
+        public override event LobbyEntityUpdatedDelegate OnEntityUpdated;
+
+        /// <summary>
+        /// This event will be invoked when an entity has been destroyed.
+        /// </summary>
+        public override event LobbyEntityDestroyedDelegate OnEntityDestroyed;
+
+        /// <summary>
         /// Constructs a server synchronizer
         /// </summary>
         public ServerSynchronizer() : base()
@@ -498,6 +528,12 @@ namespace ElectrodZMultiplayer.Server
                             server_lobby.OnStartGameCancelled += () => OnStartGameCancelled?.Invoke(server_lobby);
                             server_lobby.OnRestartGameCancelled += () => OnRestartGameCancelled?.Invoke(server_lobby);
                             server_lobby.OnStopGameCancelled += () => OnStopGameCancelled?.Invoke(server_lobby);
+                            server_lobby.OnUserEntityCreated += (user) => OnUserEntityCreated?.Invoke(server_lobby, user);
+                            server_lobby.OnUserEntityUpdated += (user) => OnUserEntityUpdated?.Invoke(server_lobby, user);
+                            server_lobby.OnUserEntityDestroyed += (user) => OnUserEntityDestroyed?.Invoke(server_lobby, user);
+                            server_lobby.OnEntityCreated += (entity) => OnEntityCreated?.Invoke(server_lobby, entity);
+                            server_lobby.OnEntityUpdated += (entity) => OnEntityUpdated?.Invoke(server_lobby, entity);
+                            server_lobby.OnEntityDestroyed += (entity) => OnEntityDestroyed?.Invoke(server_lobby, entity);
                             lobbies.Add(lobby_code, server_lobby);
                             serverUser.ServerLobby = server_lobby;
                             serverUser.SetNameInternally(message.Username);


### PR DESCRIPTION
This pull request adds `OnUserEntityCreated`, `OnUserEntityUpdated`, `OnUserEntityDestroyed`, `OnEntityCreated`, `OnEntityUpdated` and `OnEntityDestroyed` events because of #25.